### PR TITLE
Fix compilation on Visual Studio.

### DIFF
--- a/dubins/src/dubins.c
+++ b/dubins/src/dubins.c
@@ -19,7 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifdef WIN32
+#if defined(_WIN32) || defined(WIN32)
 #define _USE_MATH_DEFINES
 #endif
 #include <math.h>


### PR DESCRIPTION
Microsoft Visual Studio 2017 does not define WIN32 but defines _WIN32.
Without this change the module does not compile (is missing M_PI definition).